### PR TITLE
Backfill missing lab metadata (6 files)

### DIFF
--- a/Instructions/Labs/LAB_AK_01_Lab1_Ex1_Initialize_M365_Tenant.md
+++ b/Instructions/Labs/LAB_AK_01_Lab1_Ex1_Initialize_M365_Tenant.md
@@ -1,3 +1,14 @@
+---
+lab:
+  title: Learning Path 1 - Lab 1 - Exercise 1 - Initialize your Microsoft 365 Tenant
+  description: 'In your lab environment, your lab hosting provider has already obtained a Microsoft 365 trial tenant for you. Your lab provider has also created two admin accounts that you will use in your VM lab environment:'
+  duration: 5 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Microsoft 365
+---
+
 ## WWL Tenants - Terms of Use
 
 If you are being provided with a tenant as a part of an instructor-led training delivery, please note that the tenant is made available for the purpose of supporting the hands-on labs in the instructor-led training. 

--- a/Instructions/Labs/LAB_AK_01_Lab2_Ex1_Manage_secure_user_access.md
+++ b/Instructions/Labs/LAB_AK_01_Lab2_Ex1_Manage_secure_user_access.md
@@ -1,3 +1,15 @@
+---
+lab:
+  title: Learning Path 1 - Lab 2 - Exercise 1 - Manage secure user access
+  description: In the following lab exercise, you will continue in your role as Holly Dickson, Adatum's new Microsoft 365 Administrator. You will perform several user and group management functions within Microsoft 365. You will begin by creating a Microsoft 365 user account for Holly, who will be assigned the Microsoft 365 Global Administrator role. You will create several Microsoft 365 groups and assign existing Microsoft 365 users as members of those groups. You will then delete one of the groups and then use Windows PowerShell to recover the deleted group.
+  duration: 10 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Microsoft 365
+    - Windows
+---
+
 # Learning Path 1 - Lab 2 - Exercise 1 - Manage secure user access 
 
 Organizations must ensure that access to their company data on Microsoft 365 is always secure. Microsoft 365 often displays sensitive and confidential data, including emails, documents, customer information, and intellectual property. Unauthorized access to Microsoft 365 can lead to data breaches, identity theft, and other malicious activities. By securing user access, organizations can prevent unauthorized individuals from accessing and potentially misusing or leaking company data when working in Microsoft 365.

--- a/Instructions/Labs/LAB_AK_01_Lab2_Ex2_Manage_roles_and_role_groups.md
+++ b/Instructions/Labs/LAB_AK_01_Lab2_Ex2_Manage_roles_and_role_groups.md
@@ -1,3 +1,14 @@
+---
+lab:
+  title: Learning Path 1 - Lab 2 - Exercise 2 - Manage roles and role groups
+  description: In the prior task, you assigned an administrator role directly to Diego Siciliani's user account in the Microsoft 365 admin center. In this task, you will assign roles using a role group instead. You will create a Security role group, assign user management roles to it, and then assign the role group to Lynne Robbin's user account in the Microsoft 365 admin center.
+  duration: 60 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Microsoft 365
+---
+
 # Learning Path 1 - Lab 2 - Exercise 2 - Manage roles and role groups
 
 In this exercise, you will continue in your role as Holly Dickson, Adatum's new Microsoft 365 Administrator. As part of Adatum's Microsoft 365 pilot project, you will manage administration delegation by assigning Microsoft 365 administrator roles to several of the Microsoft 365 user accounts that were created by your lab hosting provider. This exercise will provide you with experience in using three different methods to assign these roles: 1) by assigning a role directly to a user account in the Microsoft 365 admin center, 2) by creating a role group, assigning roles to the role group, and then assigning the role group to a user in the Microsoft 365 admin center, and 3) by assigning a role to a user using Windows PowerShell. Once you have assigned Microsoft 365 admin roles to several of the existing user accounts, you will then test those assignments by verifying the users have the permissions to act in accordance with their roles.

--- a/Instructions/Labs/LAB_AK_01_Lab3_Ex1_Manage_DLP_Policies.md
+++ b/Instructions/Labs/LAB_AK_01_Lab3_Ex1_Manage_DLP_Policies.md
@@ -1,3 +1,14 @@
+---
+lab:
+  title: Learning Path 1 - Lab 3 - Exercise 1 - Manage DLP Policies
+  description: In your role as Holly Dickson, Adatum’s new Microsoft 365 Administrator, you have Microsoft 365 deployed in a virtualized lab environment. As you proceed with your Microsoft 365 pilot project, your next steps are to implement Data Loss Prevention (DLP) policies at Adatum. You will begin by creating a custom DLP policy in this exercise, and then you’ll test DLP policies related to email message archiving and emails with sensitive data.
+  duration: 84 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Microsoft 365
+---
+
 # Learning Path 1 - Lab 3 - Exercise 1 - Manage DLP Policies  
 
 In your role as Holly Dickson, Adatum’s new Microsoft 365 Administrator, you have Microsoft 365 deployed in a virtualized lab environment. As you proceed with your Microsoft 365 pilot project, your next steps are to implement Data Loss Prevention (DLP) policies at Adatum. You will begin by creating a custom DLP policy in this exercise, and then you’ll test DLP policies related to email message archiving and emails with sensitive data. 

--- a/Instructions/Labs/LAB_AK_01_Lab3_Ex2_Test_DLP_Policy.md
+++ b/Instructions/Labs/LAB_AK_01_Lab3_Ex2_Test_DLP_Policy.md
@@ -1,3 +1,12 @@
+---
+lab:
+  title: Learning Path 1 - Lab 3 - Exercise 2 - Test the DLP Policy
+  description: In this task, you will send an email from Holly Dickson to Lynne Robbins that tests the first rule (single IP address). When this rule is triggered, an email policy tip is displayed in the sender's Outlook mailbox that informs the sender the email contains sensitive data. The sender will also receive an email notification, but the email will still be sent to the recipient.
+  duration: 76 minutes
+  level: 200
+  islab: true
+---
+
 # Learning Path 1 - Lab 3 - Exercise 2 - Test the DLP Policy
 
 Holly Dickson is now at the point in her pilot project where she wants to test the DLP policy related to emails that contain sensitive information that you created in the previous lab exercise. 

--- a/Instructions/Labs/LAB_AK_01_Lab4_Ex1_Implement Sensitivity labels.md
+++ b/Instructions/Labs/LAB_AK_01_Lab4_Ex1_Implement Sensitivity labels.md
@@ -1,3 +1,17 @@
+---
+lab:
+  title: Learning Path 1 - Lab 4 - Exercise 1 - Implement Sensitivity labels with Microsoft Entra ID Protection
+  description: In the prior task, you created a Word document and protected it with the Project - Falcon sensitivity label. This label inserted a watermark in the document. In this task, you will share the document you created with Joni Sherman, and you will restrict Joni to "View only" permission. This will allow you to see how Microsoft Purview Information Protection protects the document based on the parameters that you configure.
+  duration: 15 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Microsoft Entra
+    - Microsoft Entra ID
+    - Microsoft Entra ID Protection
+    - Microsoft Purview
+---
+
 # Learning Path 1 - Lab 4 - Exercise 1 - Implement Sensitivity labels with Microsoft Entra ID Protection
 
 In your role as Holly Dickson, Adatum’s new Microsoft 365 Administrator, you have Microsoft 365 deployed in a virtualized lab environment. As you proceed with your Microsoft 365 pilot project, your next steps are to implement Sensitivity Labels with Microsoft Purview Information Protection at Adatum. In this lab, you will create and publish a label, and you will test a published label. However, in doing so, you won't test the label that you create in this lab. You will test a different label.


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 6

- `Instructions/Labs/LAB_AK_01_Lab1_Ex1_Initialize_M365_Tenant.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_AK_01_Lab2_Ex1_Manage_secure_user_access.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_AK_01_Lab2_Ex2_Manage_roles_and_role_groups.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_AK_01_Lab3_Ex1_Manage_DLP_Policies.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_AK_01_Lab3_Ex2_Test_DLP_Policy.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab)
- `Instructions/Labs/LAB_AK_01_Lab4_Ex1_Implement Sensitivity labels.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab,primarytopics)
